### PR TITLE
Rb scroll chat

### DIFF
--- a/src/components/messages/MessagesCard.js
+++ b/src/components/messages/MessagesCard.js
@@ -35,7 +35,7 @@ export class MessagesCard extends Component {
         const displayDateTime = convertDateTimeFromISO(timestamp).toLocaleString()
 
         return (
-            <div className={`${messageClasses} card`}>
+            <div className={`${messageClasses} card`} style={{ margin: "10px", backgroundColor: "azure"}}>
                 <div className="card-body">
                     {this.props.isFriendOrSelf ?
                         <span><b>{fullName}</b></span> :

--- a/src/components/messages/MessagesCard.js
+++ b/src/components/messages/MessagesCard.js
@@ -35,7 +35,7 @@ export class MessagesCard extends Component {
         const displayDateTime = convertDateTimeFromISO(timestamp).toLocaleString()
 
         return (
-            <div className={`${messageClasses} card`} style={{ margin: "10px", backgroundColor: "azure"}}>
+            <div className={`${messageClasses} card`} style={{ margin: "10px auto", backgroundColor: "azure", width: "50%"}}>
                 <div className="card-body">
                     {this.props.isFriendOrSelf ?
                         <span><b>{fullName}</b></span> :

--- a/src/components/messages/MessagesList.js
+++ b/src/components/messages/MessagesList.js
@@ -65,6 +65,11 @@ export class MessagesList extends Component {
 
 	render() {
 		const { messages } = this.state;
+		const center = {
+			textAlign: "center", 
+			width: "100%"
+		}
+
 		const scrollContainer = {
 			height: "400px",
 			overflow: "auto",
@@ -73,15 +78,17 @@ export class MessagesList extends Component {
 		return (
 			<>
 			    <div className="container-cards">
-    				<h1>Messages</h1>
-					<button 
-						type="button"
-						className="btn btn-primary"
-						onClick={()=>this.props.history.push("/messages/new")}>
-							New Message
-					</button>
+    				<div style={center}>
+    					<h1>Messages</h1>
+						<button 
+							type="button"
+							className="btn btn-primary"
+							onClick={()=>this.props.history.push("/messages/new")}>
+								New Message
+						</button>
+    				</div>
     				<div id="scroll-containre" style={scrollContainer}>
-						<div>(Oldest)</div>
+						<div style={center}>(Oldest)</div>
     					{messages.map((message) => {
 							// check for friendStatus to display button logic to add new friends
 							const isFriendOrSelf = this.state.friendIds.includes(message.userId) ||
@@ -97,7 +104,7 @@ export class MessagesList extends Component {
 	    				})}
 						{/* enables auto-scroll to the bottom of the chat window to show most recent message*/}
 						{/* https://stackoverflow.com/questions/37620694/how-to-scroll-to-bottom-in-react */}
-						<div style={{ float:"left", clear: "both" }}
+						<div style={{ float:"left", clear: "both", textAlign: "center", width: "100%" }}
              				ref={(el) => { this.messagesEnd = el; }}>(Newest)
         				</div>
     				</div>

--- a/src/components/messages/MessagesList.js
+++ b/src/components/messages/MessagesList.js
@@ -37,7 +37,14 @@ export class MessagesList extends Component {
 				newState.friendIds = [ ...newState.friendIds, friend.userId ];
 			});
 			this.setState(newState);
+			//https://stackoverflow.com/questions/37620694/how-to-scroll-to-bottom-in-react
+			this.scrollToBottom();
 		});
+	}
+
+	//https://stackoverflow.com/questions/37620694/how-to-scroll-to-bottom-in-react
+	componentDidUpdate() {
+		this.scrollToBottom();
 	}
 	
 	editMessage = id => {
@@ -52,9 +59,17 @@ export class MessagesList extends Component {
 		}
 	}
 
+	scrollToBottom = () => {
+		this.messagesEnd.scrollIntoView({ behavior: "smooth" });
+	}
+
 	render() {
 		const { messages } = this.state;
-	
+		const scrollContainer = {
+			height: "400px",
+			overflow: "auto",
+			padding: "20px",
+		}
 		return (
 			<>
 			    <div className="container-cards">
@@ -65,19 +80,27 @@ export class MessagesList extends Component {
 						onClick={()=>this.props.history.push("/messages/new")}>
 							New Message
 					</button>
-    				{messages.map((message) => {
-						// check for friendStatus to display button logic to add new friends
-						const isFriendOrSelf = this.state.friendIds.includes(message.userId) ||
-												message.userId === loggedInUserId
-						return <MessagesCard
-									key={message.id} 
-									message={message}
-									isFriendOrSelf={isFriendOrSelf}
-									editMessage={this.editMessage}
-									deleteMessage={this.deleteMessage}
-									{...this.props}
-								/>;
-    				})}
+    				<div id="scroll-containre" style={scrollContainer}>
+						<div>(Oldest)</div>
+    					{messages.map((message) => {
+							// check for friendStatus to display button logic to add new friends
+							const isFriendOrSelf = this.state.friendIds.includes(message.userId) ||
+													message.userId === loggedInUserId
+							return <MessagesCard
+										key={message.id} 
+										message={message}
+										isFriendOrSelf={isFriendOrSelf}
+										editMessage={this.editMessage}
+										deleteMessage={this.deleteMessage}
+										{...this.props}
+									/>;
+	    				})}
+						{/* enables auto-scroll to the bottom of the chat window to show most recent message*/}
+						{/* https://stackoverflow.com/questions/37620694/how-to-scroll-to-bottom-in-react */}
+						<div style={{ float:"left", clear: "both" }}
+             				ref={(el) => { this.messagesEnd = el; }}>(Newest)
+        				</div>
+    				</div>
     			</div>
 			</>
 		);


### PR DESCRIPTION
# Description

Most recent chat messages should be made visible when navigating to the `messages` view

Closes #3 
Closes #45

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

`git fetch --all`
`git checkout rb-scrollChat`
Go to `messages`. The messages view should smoothly auto-scroll to the most recent.
Also, make sure the styling of the messages shows everything centered.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
